### PR TITLE
Documentation corrections

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,23 +1,23 @@
 * evil-ediff
-Make ediff a little evil. This configures ediff to be a little more friendly
-users of vim-like keybindings. Consult the help buffer (=?=) for more info.
+Make ediff a little evil. This configures ediff to be friendlier to users
+of vim-like keybindings. Consult the help buffer (=?=) for more info.
 
 Here's a table describing the bindings
 
 | Command                     | Original Binding | Evil-ediff     |
 |-----------------------------+------------------+----------------|
-| =ediff-jump-to-difference=  | =j=              | =d=            |
-| =ediff-previous-difference= | =p,DEL=          | =C-k,N,p,DEL=  |
 | =ediff-next-difference=     | =n,SPC=          | =C-j,n,SPC=    |
+| =ediff-previous-difference= | =p,DEL=          | =C-k,N,p,DEL=  |
+| =ediff-jump-to-difference=  | =j=              | =d=            |
 | jump to first difference    | =1j=             | =gg= (or =1d=) |
 | jump to last difference     | N/A              | =G=            |
+| copy region A to region B   | =a=              | =a,l=          |
+| copy region B to region A   | =b=              | =b,h=          |
 | scroll down 1 line          | =C-u 1 v=        | =j=            |
 | scroll up 1 line            | =C-u 1 V=        | =k=            |
 | scroll down half page       | =v,C-v=          | =C-d,v,C-v=    |
 | scroll up half page         | =V,M-v=          | =C-u,V,M-v=    |
-| =ediff-suspend=             | =z=              | =C-z=          |
 | scroll left                 | =>=              | =zh=           |
 | scroll right                | =<=              | =zl=           |
-| copy A region to B's region | =a=              | =a=,=l=        |
-| copy B region to A's region | =b=              | =b=,=h=        |
 | toggle highlighting         | =h=              | =H=            |
+| =ediff-suspend=             | =z=              | =C-z=          |

--- a/evil-ediff.el
+++ b/evil-ediff.el
@@ -22,31 +22,31 @@
 
 ;;; Commentary:
 
-;; Make ediff a little evil. This configures ediff to be a little more friendly
-;; users of vim-like keybindings. Consult the help buffer (=?=) for more info.
+;; Make ediff a little evil. This configures ediff to be friendlier to users
+;; of vim-like keybindings. Consult the help buffer (=?=) for more info.
 
 ;; Here's a table describing the bindings
 
 ;; | Command                     | Original Binding | Evil-ediff  |
 ;; |-----------------------------+------------------+-------------|
-;; | ediff-jump-to-difference    | j                | d           |
-;; | ediff-previous-difference   | p,DEL            | C-k,N,p,DEL |
 ;; | ediff-next-difference       | n,SPC            | C-j,n,SPC   |
+;; | ediff-previous-difference   | p,DEL            | C-k,N,p,DEL |
+;; | ediff-jump-to-difference    | j                | d           |
 ;; | jump to first difference    | 1j               | gg (or 1d)  |
 ;; | jump to last difference     | N/A              | G           |
-;; | ediff-next-difference       | n,SPC            | C-j,n,SPC   |
+;; | copy region A to region B   | a                | a,l         |
+;; | copy region B to region A   | b                | b,h         |
 ;; | scroll down 1 line          | C-u 1 v          | j           |
 ;; | scroll up 1 line            | C-u 1 V          | k           |
 ;; | scroll down half page       | v,C-v            | C-d,v,C-v   |
 ;; | scroll up half page         | V,M-v            | C-u,V,M-v   |
-;; | ediff-suspend               | z                | C-z         |
 ;; | scroll left                 | >                | zh          |
 ;; | scroll right                | <                | zl          |
-;; | copy B region to A's region | b                | h           |
-;; | copy A region to B's region | a                | l           |
+;; | toggle highlighting         | h                | H           |
+;; | ediff-suspend               | z                | C-z         |
 
 ;; Not implemented yet
-;; | restore old diff            | rarb             | u           |
+;; | restore old diff            | ra,rb,rc         | u           |
 
 ;;; Code:
 
@@ -157,7 +157,7 @@
     ;; Not working yet
     ;; ("u"    . evil-ediff-restore-diff)
     )
-  "Alist of bindings changed/added in evil-ediff.")
+  "A list of bindings changed/added in evil-ediff.")
 
 (defun evil-ediff-startup-hook ()
   "Place evil-ediff bindings in `ediff-mode-map'."


### PR DESCRIPTION
### Changes in both evil-ediff.el and README.org:

### Description:

#### Added a missing word "to" and made a slight rewrite of the description:

Before:

> Make ediff a little evil. This configures ediff to be a little more friendly
> users of vim-like keybindings. Consult the help buffer (=?=) for more info.

After:

> Make ediff a little evil. This configures ediff to be friendlier to users
> of vim-like keybindings. Consult the help buffer (=?=) for more info.

### Correct the "table describing the bindings":

- Moved down `ediff-jump-to-difference` two lines so that it's grouped with
the other two jump commands.

- Reordered the `ediff-previous-difference` and `ediff-next-difference`
commands so that next is first, because it's probably the most used command,
that also makes them match the order of the scroll commands, down (next)
before up (previous).

- Moved `ediff-suspend` to the bottom, because it's the last command in the
ediff control panel, and alphabetically "z" probably fits better at the bottom.
And moving it also groups the scroll commands together.

- Moved up the "copy A region to B's region" and "copy B region to A's region"
commands below the "navigate to a difference" commands, because they are
probably the second most used commands, one first navigates to a difference and
then copies one set of changes.
  - Rewrote the names without "'s".
  - Added "a" and "b" as keys in the Evil-ediff column, because they still work
  to copy regions, and they are listed in README.org

### evil-ediff.el specific changes:

- Removed a duplicate line
```
;; | ediff-next-difference       | n,SPC            | C-j,n,SPC   |
```

- Reordered "copy A region to B's region" and "copy B region to A's region" to
sort them alphabetically, that also makes them match the order in README.org.

- Added the toggle highlight command, it was only listed in README.org
```
;; | toggle highlighting         | h                | H           |
```
- Separated the original bindings "rarb", and added the missing 3rd binding "rc"
before:
```
;; | restore old diff            | rarb             | u           |
```
after:
```
;; | restore old diff            | ra,rb,rc         | u           |
```
- The docstring for `defvar evil-ediff-bindings` was missing a space between
"A" and "list":
before:
`  "Alist of bindings changed/added in evil-ediff.")`

after:
`  "A list of bindings changed/added in evil-ediff.")`

### README.org specific changes:

The Evil-ediff bindings "=l=" and "=h=" for the "copy A region to B's region"
commands, are showing the "=" equal signs around the letters. By looking at
how the other bindings are written in README.org one can see that the inner
equal signs should be removed:
before:
```
| copy A region to B's region | =a=              | =a=,=l=        |
| copy B region to A's region | =b=              | =b=,=h=        |
```
after:
```
| copy A region to B's region | =a=              | =a,l=          |
| copy B region to A's region | =b=              | =b,h=          |
```